### PR TITLE
Use constant size for ring-buffer in/out buffers.

### DIFF
--- a/APRSGateway.cpp
+++ b/APRSGateway.cpp
@@ -181,12 +181,12 @@ void CAPRSGateway::run()
 	LogMessage("Starting APRSGateway-%s", VERSION);
 
 	for (;;) {
-		unsigned char buffer[500U];
+		unsigned char buffer[FRAME_BUFFER_SIZE];
 		in_addr address;
 		unsigned int port;
 
 		// From a gateway to aprs.fi
-		unsigned int len = aprsSocket.read(buffer, 500U, address, port);
+		unsigned int len = aprsSocket.read(buffer, FRAME_BUFFER_SIZE, address, port);
 		if (len > 0U)
 			writer->write(buffer, len);
 

--- a/APRSWriterThread.cpp
+++ b/APRSWriterThread.cpp
@@ -127,7 +127,7 @@ void CAPRSWriterThread::entry()
 					unsigned int length = 0U;
 					m_queue.getData((unsigned char*)&length, sizeof(unsigned int));
 
-					unsigned char p[500U];
+					unsigned char p[FRAME_BUFFER_SIZE];
 					m_queue.getData(p, length);
 
 					if (m_debug)

--- a/APRSWriterThread.h
+++ b/APRSWriterThread.h
@@ -26,6 +26,8 @@
 
 #include <string>
 
+const unsigned int FRAME_BUFFER_SIZE = 300U;
+
 typedef void (*ReadAPRSFrameCallback)(const std::string&);
 
 class CAPRSWriterThread : public CThread {


### PR DESCRIPTION
Here is the quote from the comment in #3 

Hi Jonathan,

> The second part of this makes no sense as the length of the buffer is limited to 255 bytes because the length is held in a single unsigned char. This probably needs changing, but making the buffer larger than 300 makes no difference.

It's not what I read in the code (I just double checked to be sure). The uint32_t length is stored in 4 bytes:

`bool ret = m_queue.addData((unsigned char*)&length, sizeof(unsigned int));`

and since recvfrom() will limit the data to the buffer size, and discard the extraneous ones, using a larger buffer to store these data in the ringbuffer and a smaller one to retrieve them (without checking of the destination buffer size), is potientially a problem.
Maybe just defining a constant about the buffer size, shared by both buffer would be better.

Cheers.
...
Daniel
