### PR TITLE
Version string (git id) consistency with other clients/gateways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ x64
 *.VC.db
 .vs
 APRSGateway
-
+GitVersion.h

--- a/APRSGateway.cpp
+++ b/APRSGateway.cpp
@@ -25,6 +25,7 @@
 #include "Timer.h"
 #include "Utils.h"
 #include "Log.h"
+#include "GitVersion.h"
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <Windows.h>
@@ -59,7 +60,7 @@ int main(int argc, char** argv)
 		for (int currentArg = 1; currentArg < argc; ++currentArg) {
 			std::string arg = argv[currentArg];
 			if ((arg == "-v") || (arg == "--version")) {
-				::fprintf(stdout, "APRSGateway version %s\n", VERSION);
+				::fprintf(stdout, "APRSGateway version %s git #%.7s\n", VERSION, gitversion);
 				return 0;
 			} else if (arg.substr(0, 1) == "-") {
 				::fprintf(stderr, "Usage: APRSGateway [-v|--version] [filename]\n");
@@ -184,7 +185,8 @@ void CAPRSGateway::run()
 	CStopWatch stopWatch;
 	stopWatch.start();
 
-	LogMessage("Starting APRSGateway-%s", VERSION);
+	LogMessage("APRSGateway-%s is starting", VERSION);
+ 	LogMessage("Built %s %s (GitID #%.7s)", __TIME__, __DATE__, gitversion);
 
 	for (;;) {
 		unsigned char buffer[FRAME_BUFFER_SIZE];

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,18 @@ APRSGateway:	$(OBJECTS)
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
+APRSGateway.o: GitVersion.h FORCE
+
+.PHONY: GitVersion.h
+
+FORCE:
+
+
 install:
 		install -m 755 APRSGateway /usr/local/bin/
 
 clean:
-		$(RM) APRSGateway *.o *.d *.bak *~
- 
+		$(RM) APRSGateway *.o *.d *.bak *~ GitVersion.h
+
+GitVersion.h:
+		echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,10 @@ install:
 clean:
 		$(RM) APRSGateway *.o *.d *.bak *~ GitVersion.h
 
+# Export the current git version if the index file exists, else 000...
 GitVersion.h:
-		echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@ 
+ifneq ("$(wildcard .git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif


### PR DESCRIPTION
This PR makes APRSGateway's version str. and log version messages consistent with other `G4KLX` clients/gateways  (YSFClients, DMRGateway, etc).