### PR TITLE
Replace deprecated lambda to fix compile warning

### DIFF
--- a/APRSWriterThread.cpp
+++ b/APRSWriterThread.cpp
@@ -53,7 +53,7 @@ m_version(version)
 	assert(port > 0U);
 
 	m_username.resize(CALLSIGN_LENGTH, ' ');
-	m_username.erase(std::find_if(m_username.rbegin(), m_username.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), m_username.end());
+	m_username.erase(std::find_if(m_username.rbegin(), m_username.rend(), [](unsigned char c) { return !std::isspace(c); }).base(), m_username.end());
 	std::transform(m_username.begin(), m_username.end(), m_username.begin(), ::toupper);
 }
 


### PR DESCRIPTION
Hi. Jonathan 

I hope you don't mind, but I thought I would just go through the various MMDVM projects and fix compile warnings when I find them. APRSGateway had a single C++11 era lambda that is deprecated in newer C++ so I replaced it with a more universal lambda.

73 Phil M0VSE